### PR TITLE
Fix thread safe issue on vivo and Motorola Android 12

### DIFF
--- a/library/src/main/java/org/simple/eventbus/EventBus.java
+++ b/library/src/main/java/org/simple/eventbus/EventBus.java
@@ -369,8 +369,11 @@ public final class EventBus {
          */
         void dispatchEvents(Object aEvent) {
             Queue<EventType> eventsQueue = mLocalEvents.get();
-            while (eventsQueue.size() > 0) {
-                deliveryEvent(eventsQueue.poll(), aEvent);
+            if (eventsQueue != null) {
+                EventType eventType;
+                while ((eventType = eventsQueue.poll()) != null) {
+                    deliveryEvent(eventType, aEvent);
+                }
             }
         }
 


### PR DESCRIPTION
Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'int java.lang.Object.hashCode()' on a null object reference
       at j$.util.concurrent.ConcurrentHashMap.get()
       at j$.util.concurrent.ConcurrentHashMap.containsKey()
       at org.simple.eventbus.EventBus$EventDispatcher.getMatchedEventTypes(EventBus.java:393)
       at org.simple.eventbus.EventBus$EventDispatcher.deliveryEvent(EventBus.java:363)
       at org.simple.eventbus.EventBus$EventDispatcher.dispatchEvents(EventBus.java:351)
       at org.simple.eventbus.EventBus.post(EventBus.java:189)